### PR TITLE
feat(sublist): generate flamegraphs

### DIFF
--- a/sublist/Cargo.toml
+++ b/sublist/Cargo.toml
@@ -7,7 +7,8 @@ version = "0.0.0"
 rayon = "1.6.1"
 
 [dev-dependencies]
-criterion = { version = "0.3", features = ["html_reports"]}
+criterion = { version = "0.4", features = ["html_reports"]}
+pprof = { version = "0.11.0", features = ["flamegraph", "criterion"] }
 
 [[bench]]
 name = "sublist"

--- a/sublist/benches/flamegraphs.html
+++ b/sublist/benches/flamegraphs.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Threads Flamegraphs</title>
+</head>
+
+<!--
+    In order to generate these flamegraphs, run the following:
+
+    cargo bench --bench sublist -- --profile-time=5
+-->
+
+<body>
+    <h2>Threads, 100</h2>
+    <img src="../target/criterion/Sublist/Threads, 100/100/profile/flamegraph.svg" />
+    <h2>Threads, 260135</h2>
+    <img src="../target/criterion/Sublist/Threads, 260135/260135/profile/flamegraph.svg" />
+    <h2>Threads, 520271</h2>
+    <img src="../target/criterion/Sublist/Threads, 520271/520271/profile/flamegraph.svg" />
+</body>
+
+</html>

--- a/sublist/benches/sublist.rs
+++ b/sublist/benches/sublist.rs
@@ -2,6 +2,7 @@ use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Through
 use sublist::{sublist, Method};
 use std::fs;
 
+use pprof::criterion::{Output, PProfProfiler};
 
 static LARGE_STRING: &str = include_str!("large_input.txt");
 static SUBSTRING: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -39,7 +40,11 @@ fn bench_sublist(c: &mut Criterion) {
     }
 }
 
-criterion_group!(benches, bench_sublist);
+criterion_group!(
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = bench_sublist
+);
 criterion_main!(benches);
 
 


### PR DESCRIPTION
Next step would be to figure out why stuff is taking so long. Flamegraphs are a really helpful tool for that. I added flamegraph generation based on  [this blog post](https://www.jibbow.com/posts/criterion-flamegraphs/). It was barely any work, since pprof and criterion work incredibly well with each other.

The blog most mentions this only works on linux though... not sure what OS you're running.

I've included a comment with instructions to generate in the little convenience html file:
```
cargo bench --bench sublist -- --profile-time=5
```

It looks to me like much time is spend in syscalls, waiting on locks specifically.

I'm including my results here, in case there's trouble getting it to run on your machine:

---

Threads, 100

![flamegraph](https://user-images.githubusercontent.com/54984957/210078402-f2a50f9e-a2de-48fd-bfed-9cf6e403fa8a.svg)

---

Threads, 260135

![flamegraph](https://user-images.githubusercontent.com/54984957/210078529-0ea3b34c-8a01-47a7-9f92-736793150775.svg)

---

Threads, 520271

![flamegraph](https://user-images.githubusercontent.com/54984957/210078589-3264027d-b2fc-4fe6-8f8e-80739b7d95ee.svg)